### PR TITLE
Java source upgrade

### DIFF
--- a/rankings.html
+++ b/rankings.html
@@ -11,128 +11,20 @@
 <script src="https://cdn.datatables.net/v/dt/jq-3.7.0/dt-2.0.7/b-3.0.2/b-html5-3.0.2/r-3.0.2/sb-1.7.1/sp-2.3.1/sl-2.0.1/datatables.min.js"></script>
 <script src="rankings_script.js"></script>
 
-<div class="lds-dual-ring"></div>
+<div class="loaders">
+	<div class="skelbox"></div>
+	<div class="skelbox1"></div>
+	<div class="skelbox1"></div>
+	<div class="spinner"></div>
+	<h3 style="text-align:center; font-family:'Montserrat'; color:#2f2f2f; letter-spacing: 3px; font-size:100%">&nbsp;&nbsp;&nbsp;Loading...</h3>
+	<div class="skelbox1"></div>
+	<div class="skelbox1"></div>
+	<div class="skelbox1"></div>
+</div>
 
 <div class="hider" hidden>
-<table id="myTable" style="width:100%" class="maintable">
-	<thead>
-		<tr>
-			<th class="all">Rank</th>
-			<th class="all">Journal Name (Linked)</th>
-			<th class="all">Area</th>
-			<th class="all">4YAP</th>
-			<th class="none">Paper Length</th>
-			<th class="none">Open Access</th>
-			<th class="none">Book Reviews</th>
-			<th class="none">Discussions</th>
-			<th class="all">SJR</th>
-			<th class="all">SNIP</th>
-			<th class="all">CiSc</th>
-			<th class="all">CTE%</th>
-			<th class="all">GSH5</th>
-			<th class="all">SJRH</th>
-			<th class="all">Leit</th>
-			<th class="all">BrQu</th>
-			<th class="all">BrAw</th>
-			<th class="all">Acpt</th>
-			<th class="all">Subs</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td></td>
-			<td>
-			<a href="https://pjip.org" target="_blank" rel="noopener noreferrer">Example Journal 1</a>
-			</td>
-			<td>GNRL</td>
-			<td>8</td>
-			<td>Standard</td>
-			<td>NOA</td>
-			<td>Inv.</td>
-			<td>NDIS</td>
-			<td>3.43</td>
-			<td>5.11</td>
-			<td>6.3</td>
-			<td>81%</td>
-			<td>20</td>
-			<td>61</td>
-			<td>89</td>
-			<td>4.6</td>
-			<td>94.59</td>
-			<td>2%</td>
-			<td>400</td>
-		</tr>
-		<tr>
-			<td></td>
-			<td>
-			<a href="https://pjip.org" target="_blank" rel="noopener noreferrer">Example Journal 2</a>
-			</td>
-			<td>GNRL</td>
-			<td>41.5</td>
-			<td>Standard</td>
-			<td>HYBD</td>
-			<td>Inv.</td>
-			<td>RTJA</td>
-			<td>2.74</td>
-			<td>4.13</td>
-			<td>5.5</td>
-			<td>82%</td>
-			<td>39</td>
-			<td>78</td>
-			<td>87</td>
-			<td>4.64</td>
-			<td>96.58</td>
-			<td>5%</td>
-			<td>200</td>
-		</tr>
-		<tr>
-			<td></td>
-			<td>
-			<a href="https://pjip.org" target="_blank" rel="noopener noreferrer">Example Journal 3</a>
-			</td>
-			<td>GNRL</td>
-			<td>75.75</td>
-			<td>Standard</td>
-			<td>HYBD</td>
-			<td>Inv.</td>
-			<td>RTJA</td>
-			<td>1.53</td>
-			<td>2.1</td>
-			<td>3.2</td>
-			<td>66%</td>
-			<td>34</td>
-			<td>48</td>
-			<td>86</td>
-			<td>4.64</td>
-			<td>95.16</td>
-			<td>10%</td>
-			<td>250</td>
-		</tr>
-		<tr>
-			<td></td>
-			<td>
-			<a href="https://pjip.org" target="_blank" rel="noopener noreferrer">Example Journal 4</a>
-			</td>
-			<td>M&P</td>
-			<td>10</td>
-			<td>SHort</td>
-			<td>HYBD</td>
-			<td>YBKR</td>
-			<td>RTJA</td>
-			<td>0.3</td>
-			<td>0.6</td>
-			<td>0.3</td>
-			<td>22%</td>
-			<td>4</td>
-			<td>44</td>
-			<td>20</td>
-			<td>0.62</td>
-			<td>22.87</td>
-			<td>50%</td>
-			<td>400</td>
-		</tr>
-	</tbody>
-</table>
+<table id="myTable" style="width:100%" class="maintable"></table>
 </div>
+
 </body>
 </html>

--- a/rankings_script.js
+++ b/rankings_script.js
@@ -1,45 +1,116 @@
+// Data source as JSON Array
+const dataSet =  [
+	["","Example Journal 1","GNRL",8,"Standard","NOA","Inv.","NDIS",3.43,5.11,6.3,"81%",20,61,89,4.6,94.59,"2%",400  ],
+  	["","Example Journal 2","GNRL",41.5,"Standard","HYBD","Inv.","RTJA",2.74,4.13,5.5,"82%",39,78,87,4.64,96.58,"5%",200  ],
+  	["","Example Journal 3","GNRL",75.75,"Standard","HYBD","Inv.","RTJA",1.53,2.1,3.2,"66%",34,48,86,4.64,95.16,"10%",250  ],
+  	["","Example Journal 4","M&P",10,"SHort","HYBD","YBKR","RTJA",0.3,0.6,0.3,"22%",4,44,20,0.62,22.87,"50%",400  ]
+]
+
 $(document).ready( function () {
 	var table = $('#myTable').DataTable({
-		initComplete: function (settings, json) {
-			$("div.hider").removeAttr('hidden');
-			$("div.lds-dual-ring").remove();
-			this.api().columns.adjust();
-    			},
-		layout: {
-        		top1: 'searchPanes',
-			topEnd: null
-    			},
-		order: [[8, 'desc']],
-		
-		responsive: {
-			details: {
-				type: 'none'}
- 				},
-		
-		"scrollY": "700px",
-		"scrollX": true,
-	 	"pageLength": 50,
-		"lengthMenu": [ [10, 25, 50, -1], [10, 25, 50, "All"] ],
-		"processing": true,
-		searchPanes: {
-			columns: [2, 4, 5, 6, 7],
-			orderable: false,
-			viewTotal: true,
-			initCollapsed: true,
-			layout: 'columns-5'},
+columns: [
+	{ title: 'Rank',
+		className: 'all'
+	},
+	{ title: 'Journal Name (Linked)',
+		className: 'all'
+	},
+	{ title: 'Area',
+		className: 'all'
+	},
+	{ title: '4YAP',
+		className: 'all'
+	},
+	{ title: 'Paper Length',
+		className: 'none'
+	},
+	{ title: 'Open Access',
+		className: 'none'
+	},
+	{ title: 'Book Reviews',
+		className: 'none'
+	},
+	{ title: 'Discussions',
+		className: 'none'
+	},
+	{ title: 'SJR',
+		className: 'all'
+	},
+	{ title: 'SNIP',
+		className: 'all'
+	},
+	{ title: 'CiSc',
+		className: 'all'
+	},
+	{ title: 'CTE%',
+		className: 'all'
+	},
+	{ title: 'GSH5',
+		className: 'all'
+	},
+	{ title: 'SJRH',
+		className: 'all'
+	},
+	{ title: 'Leit',
+		className: 'all'
+	},
+	{ title: 'BrQu',
+		className: 'all'
+	},
+	{ title: 'BrAw',
+		className: 'all'
+	},
+	{ title: 'Acpt',
+		className: 'all'
+	},
+	{ title: 'Subs',
+		className: 'all'
+	},
+],
+
+data: dataSet,
+
+initComplete: function (settings, json) {
+	$("div.hider").removeAttr('hidden');
+	$("div.loaders").remove();
+	this.api().columns.adjust();
+},
+
+layout: {
+	top1: 'searchPanes',
+	topEnd: null
+	},
+order: [[8, 'desc']],
+
+responsive: {
+	details: {
+		type: 'none'}
+		},
+
+"scrollY": "700px",
+"scrollX": true,
+"pageLength": 50,
+"lengthMenu": [ [10, 25, 50, -1], [10, 25, 50, "All"] ],
+"processing": true,
+searchPanes: {
+	columns: [2, 4, 5, 6, 7],
+	orderable: false,
+	viewTotal: true,
+	initCollapsed: true,
+	layout: 'columns-5'},
 
 columnDefs: [
 
 //One way ordering for metrics so they match index (find a better solution?)//
-		{ orderSequence: ['desc'], targets: [3, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18] },
-		{ orderSequence: ['asc'], targets: [17] },
+{ orderSequence: ['desc'], targets: [3, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18] },
+{ orderSequence: ['asc'], targets: [17] },
 
 //Set don't search and don't order columns//
-		{ searchable: false, targets: [0] },
-		{ orderable: false, targets: [0, 1, 2] },
+{ searchable: false, targets: [0] },
+{ orderable: false, targets: [0, 1, 2] },
 
 //formatting//
-		{className:"dt-body-center", targets:[0, 3] },
+{className:"dt-body-center", targets:[0, 3] },
 
 //SJR Rankings //
 {targets:[8], className:"dt-body-center",

--- a/rankings_style.css
+++ b/rankings_style.css
@@ -66,41 +66,63 @@ table.dataTable.maintable tbody tr > .sorting_3 {
 	background-color: #E6E8F0;
 }
 
-.lds-dual-ring {
-  color: #1c4c5b
-}
-.lds-dual-ring,
-.lds-dual-ring:after {
-  box-sizing: border-box;
-}
-.lds-dual-ring {
-  display: inline-block;
-  width: 80px;
-  height: 80px;
-}
-.lds-dual-ring:after {
-  content: " ";
-  display: block;
-  width: 64px;
-  height: 64px;
-  margin: 8px;
-  border-radius: 50%;
-  border: 6.4px solid currentColor;
-  border-color: currentColor transparent currentColor transparent;
-  animation: lds-dual-ring 1.2s linear infinite;
-}
-@keyframes lds-dual-ring {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-}
-
 .hider {
 	padding: 0;
 	margin: 0;
 	width: 100%;
+}
+
+/* Skeletal Loaders */
+
+.skelbox {
+  margin: 1rem;
+  min-height: 4rem;
+  border-radius: 4px;
+	background-color: #ededed;
+}
+
+.skelbox1 {
+  margin: 1rem;
+  min-height: 2rem;
+  border-radius: 4px;
+  animation-delay: .06s;
+	background-color: #ededed;
+}
+
+/* Loading spinner*/
+.spinner {
+   width: 56px;
+   height: 56px;
+   display: grid;
+   border: 4.5px solid #0000;
+   border-radius: 50%;
+   border-right-color: #3f3f3f;
+   animation: spinner-a4dj62 1s infinite linear;
+   margin: 3rem auto 3rem auto;
+}
+
+.spinner::before,
+.spinner::after {
+   content: "";
+   grid-area: 1/1;
+   margin: 2.2px;
+   border: inherit;
+   border-radius: 50%;
+   animation: spinner-a4dj62 2s infinite;
+}
+
+.spinner::after {
+   margin: 8.9px;
+   animation-duration: 3s;
+}
+
+@keyframes spinner-a4dj62 {
+   100% {
+      transform: rotate(1turn);
+   }
+}
+
+.loaders {
+	margin: 2rem 0 30rem 0;
 }
 


### PR DESCRIPTION
Changed data source from HTML table to JSON array. 
Added improved loading spinner.

Allows for improved loading speeds when working with larger datasets.

For reference:
Small dataset (>100 rows) = nominal difference in loading speeds.

Loading Ranking index containing 18 columns / 200 rows with data sourced from an HTML table:
	Average page loading time: 4927ms
Same table when the data is sourced from a JSON Array:
	Average page loading time: 4250ms

Loading Ranking index containing 18 columns / 1000 rows with data sourced from an HTML table:
	Average page loading time: 13233ms
Same table when the data is sourced from a JSON Array:
	Average page loading time: 5567ms

Beyond 1,000 rows HTML tables become unfeasible due to the number of entities the DOM has to create (this is avoided when using a Javascript source as loading data is deferred until displayed - 50 rows per page). 

Using a Javascript source works ~10,000 entries before becoming unmanageably slow - at that point, Server-side processing would be apt.

(All tested with standardised performance data from Chrome Console for PJIP website using Datatables 2.0 and the JournalRankingIndex v.1 Release). 